### PR TITLE
(feat): upgrade imports to support Deno 1.4.0 strict type imports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: denolib/setup-deno@master
         with:
-          deno-version: 1.0.0
+          deno-version: 1.4.0
 
       - run: deno --version
       - run: deno fmt --check

--- a/deps.ts
+++ b/deps.ts
@@ -1,6 +1,6 @@
-import Negotiator from "https://deno.land/x/negotiator@1.0.0/mod.ts";
+import Negotiator from "https://deno.land/x/negotiator@1.0.1/mod.ts";
 export {
   Negotiator,
 };
 
-export { lookup } from "https://deno.land/x/media_types@v2.4.1/mod.ts";
+export { lookup } from "https://deno.land/x/media_types@v2.4.7/mod.ts";

--- a/example/server.ts
+++ b/example/server.ts
@@ -1,7 +1,7 @@
 import {
   serve,
   Response,
-} from "https://deno.land/std/http/server.ts";
+} from "https://deno.land/std@0.69.0/http/server.ts";
 import { Accepts } from "../mod.ts";
 
 const server = serve("127.0.0.1:3000");

--- a/readme.md
+++ b/readme.md
@@ -75,7 +75,7 @@ server.
 import {
   serve,
   Response,
-} from "https://deno.land/std/http/server.ts";
+} from "https://deno.land/std@0.69.0/http/server.ts";
 import { Accepts } from "../mod.ts";
 
 const server = serve("127.0.0.1:3000");

--- a/test/deps.ts
+++ b/test/deps.ts
@@ -1,4 +1,4 @@
 // std
 export {
   assertEquals,
-} from "https://deno.land/std@0.60.0/testing/asserts.ts";
+} from "https://deno.land/std@0.69.0/testing/asserts.ts";


### PR DESCRIPTION
Fixes https://github.com/ako-deno/accepts/issues/2 for Deno 1.4.0 strict type import/export syntax.

Also updates std package imports to versioned imports as unversioned imports cause a warning and have been marked as unsafe. See https://deno.land/x/#info and https://github.com/denoland/deno_website2/issues/997